### PR TITLE
add i3 mode module in polybar

### DIFF
--- a/polybar/config.ini
+++ b/polybar/config.ini
@@ -41,7 +41,7 @@ font-1 = "Hack Nerd Font:size=10;3"
 font-2 = "feather:size=12;3"
 modules-left = workspaces sep cpu memory filesystem temperature system-fan-speed cpu-graph 
 modules-center = title
-modules-right = leftwm-layout keyboard network bluetooth volume backlight battery date
+modules-right = mode leftwm-layout keyboard network bluetooth volume backlight battery date
 separator =
 dim-value = 1.0
 wm-name = LeftWM

--- a/polybar/user_modules.ini
+++ b/polybar/user_modules.ini
@@ -26,6 +26,14 @@ format-prefix-foreground = ${color.purple}
 exec = ./scripts/system-fan-speed.sh
 interval = 5
 
+[module/mode]
+type = internal/i3
+label-mode = %mode%
+label-mode-padding = 1
+format-prefix-foreground = ${color.yellow}
+format-prefix = 
+format = <label-mode>
+
 [module/launcher]
 type = custom/text
 content = 


### PR DESCRIPTION
This pull request adds the i3 mode module to your polybar. This is very useful to have especially when you start to make use of alot of modes in your i3 which might sometimes make it hard for you to figure out which mode you are in and also exit that mode when appropriate.